### PR TITLE
fix(page): fix forced remounts on client side app render

### DIFF
--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -12,6 +12,7 @@ export interface PageProps {
   id?: string;
   pageData?: APIPage;
 }
+
 @Component({
   name: "FSXAPage",
 })
@@ -31,6 +32,16 @@ class Page extends BaseComponent<PageProps> {
     if (id !== prevId && id != null) {
       this.fetchPage();
     }
+  }
+
+  // use [key] to force re-render if needed.
+  // Load initial Value from Store if available, so that ServerRendered and Client Key are synced
+  get key(): string {
+    return this.$store.state.pageComponentKey || "fsxa_page_" + 1;
+  }
+
+  set key(value: string) {
+    this.$store.state.pageComponentKey = value;
   }
 
   mounted() {
@@ -75,16 +86,14 @@ class Page extends BaseComponent<PageProps> {
         locale: this.locale,
       });
       this.setStoredItem(this.id, page);
+      // Update key in store, so that it may be loaded from client after ssr
+      this.key = "fsxa_page_" + Date.now();
     } catch (err) {
       this.setStoredItem(this.id, null);
     }
   }
 
-  // ✨ use [key] to re-render on store changes {@see https://michaelnthiessen.com/force-re-render/}
-  key = Date.now();
-
   get loadedPage(): APIPage | null | undefined {
-    this.key = Date.now(); // update the [key] any time the store item gets updated
     return this.id ? this.getStoredItem(this.id) : undefined;
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,6 +32,7 @@ export interface FSXAVuexState {
   navigation: NavigationData | null;
   settings: ProjectProperties | null;
   error: FSXAAppError | null;
+  pageComponentKey: string | null;
   stored: {
     [key: string]: {
       ttl: number;
@@ -104,6 +105,7 @@ export function getFSXAModule<R extends RootState>(
       settings: null,
       appState: FSXAAppState.not_initialized,
       error: null,
+      pageComponentKey: null,
       fsxaApiMode: options.mode,
       mode: options.config.contentMode,
       configuration: options.config,

--- a/src/utils/tpp-snap-hooks.ts
+++ b/src/utils/tpp-snap-hooks.ts
@@ -6,8 +6,6 @@ import {
 
 const CAAS_CHANGE_DELAY_IN_MS = 300;
 
-export const CUSTOM_TPP_UPDATE_EVENT = "tpp-update";
-
 export type RegisterTppHooksOptions = {
   fsxaApi: FSXAApi;
   TPP_SNAP: any;
@@ -63,7 +61,7 @@ export const registerTppHooks = async ({
           return false;
         } else if ($node) {
           const canceled = !$node.dispatchEvent(
-            new CustomEvent(CUSTOM_TPP_UPDATE_EVENT, {
+            new CustomEvent("tpp-update", {
               bubbles: true,
               cancelable: true,
               detail: { previewId, content },


### PR DESCRIPTION
the key handling used led to multiple complete re-renders of the fsxa-pwa. Re-renders are now only
forced when new data was pulled. Reimplemented previous fix, as it led to problems with the nuxt-module