### PR TITLE
fix(storeTTL): read storeTTL from nuxt config

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -33,6 +33,7 @@ import { AppProps } from "@/types/components";
 import PortalProvider from "./internal/PortalProvider";
 import { importTPPSnapAPI } from "@/utils";
 import {
+  getStoreTTL,
   getStoredItem,
   isExactDatasetRoutingEnabled,
   triggerRouteChange,
@@ -46,7 +47,6 @@ class App extends TsxComponent<AppProps> {
   @Prop({ default: () => ({}) }) components!: AppProps["components"];
   @Prop() currentPath!: AppProps["currentPath"];
   @Prop({ default: false }) devMode!: AppProps["devMode"];
-  @Prop({ default: 300000 }) storeTTL!: AppProps["storeTTL"];
   @Prop({ required: true }) defaultLocale!: AppProps["defaultLocale"];
   @Prop({ required: true }) handleRouteChange!: AppProps["handleRouteChange"];
   @Prop() fsTppVersion: AppProps["fsTppVersion"];
@@ -56,7 +56,7 @@ class App extends TsxComponent<AppProps> {
   @ProvideReactive("currentPath") path = this.currentPath;
   @ProvideReactive(FSXA_INJECT_KEY_DEV_MODE) injectedDevMode = this.devMode;
 
-  @ProvideReactive(FSXA_STORE_TTL) injectedTTL = this.storeTTL;
+  @ProvideReactive(FSXA_STORE_TTL) injectedTTL = getStoreTTL(this);
 
   @ProvideReactive(FSXA_INJECT_KEY_CUSTOM_SNAP_HOOKS)
   injectedCustomSnapHooks = this.customSnapHooks;

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -316,11 +316,6 @@ export interface AppProps {
   devMode?: boolean;
 
   /**
-   * defines default time to live for StoreElements in Milliseconds. -1 => No TTL, always valid
-   */
-  storeTTL?: number;
-
-  /**
    * Required callback that will be triggered, when the route should be changed
    *
    * Info: We do not know in which context you are using our pattern-library, so we decided that you should have the last word about routing.

--- a/src/utils/getters.ts
+++ b/src/utils/getters.ts
@@ -189,3 +189,10 @@ export function displayHiddenSections(vue: Vue): boolean {
   if (!(vue as any).$config) return true;
   return (vue as any).$config.FSXA_DISPLAY_HIDDEN_SECTIONS !== false;
 }
+
+export function getStoreTTL(vue: Vue): number {
+  // Assuming that pattern lib is used in Nuxt environment where $config is available.
+  if (!(vue as any).$config) return 300000;
+  const storeTTL = (vue as any).$config.FSXA_STORE_TTL;
+  return "number" === typeof storeTTL ? storeTTL : 300000;
+}


### PR DESCRIPTION
Provide nuxt runtime config with FSXA_STORE_TLL 
value of -1 means indefinite TTL