### PR TITLE
feat(defaultlocale): use FSXA_LOCALE from runtimeConfig as DefaultLocale if set

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -149,7 +149,8 @@ class App extends TsxComponent<AppProps> {
 
   initialize(locale?: string, path?: string) {
     const payload: InitializeAppPayload = {
-      locale: locale ? locale : this.defaultLocale,
+      locale:
+        locale || (this as any).$config?.FSXA_LOCALE || this.defaultLocale,
       initialPath: path ? path : this.currentPath,
       useExactDatasetRouting: isExactDatasetRoutingEnabled(this),
       remoteDatasetProjectId: getRemoteDatasetProjectId(this),


### PR DESCRIPTION
Before, the defaultLocale was set during Build, the FSXA_LOCALE was ignored during runtime. 



