### PR TITLE
feat(proxy-api for remote dataset routing): use separate configurable …

### DIFF
--- a/docs/RemoteDatasets.md
+++ b/docs/RemoteDatasets.md
@@ -1,15 +1,17 @@
 ## RemoteDatasets
 
 the neo-fsxa-pattern-library can support a specific implementation of remote datasets.
-Those Datasets must be available in the CaaS of the specified remote project with the same FSXA_API_KEY as the project itself uses.
+Those Datasets can be fetched via a separate fsxa remote Api managed by the Users Application, that will be requested by a proxy Api created by fsxa-pattern-library
+This Remote Api should connect to the CaaS of the remote Project.
 
 Must be used with ExactDatasetRouting.
 
-To configure remote Datasets, add the following line to your .env and your nuxt public runtime
+To configure remote Datasets, add the following line to your .env and your nuxt public runtime.
 
-`FSXA_REMOTE_DATASET_PROJECT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+`FSXA_REMOTE_DATASET_PROXY_API_PATH=/path/to/remote/api`
 
 If this is set, the pattern lib will try to resolve routes from that projects CaaS regarding to its Datatets. Those Routes are only taken into Account, if no local route can be resolved.
+The fsxa-pattern-lib will create a separate fsxa-proxy-api connecting to this path only used for remote dataset routing.
 
 To make sure, that a valid PageRef can be used to display those Datasets, one may add a mapping to map REMOTE_PAGEREF_ID to LOCAL_PAGEREF_ID
 
@@ -19,4 +21,4 @@ Additionally, you may configure the variable `FSXA_VALID_LANGUAGES`, which will 
 
 `FSXA_VALID_LANGUAGES=["DE_DE", "EN_US"]`
 
-Note that the values in this Array must coincide with the identifier of a Language in the CaaS found in each Document under "locale.identifier"
+Note that the values in this Array must coincide with the identifier of a Language in the CaaS found in each Document under "locale.identifier", not the CaaS Locales.

--- a/src/components/App.spec.tsx
+++ b/src/components/App.spec.tsx
@@ -66,7 +66,7 @@ describe("App", () => {
       locale: "de",
       initialPath: "/some/path",
       useExactDatasetRouting: false,
-      remoteDatasetProjectId: undefined,
+      remoteDatasetProxyApiPath: undefined,
       remoteDatasetPageRefMapping: undefined,
     };
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -34,7 +34,7 @@ import PortalProvider from "./internal/PortalProvider";
 import { importTPPSnapAPI } from "@/utils";
 import {
   getRemoteDatasetPageRefMapping,
-  getRemoteDatasetProjectId,
+  getRemoteDatasetProxyApiPath,
   getStoreTTL,
   getStoredItem,
   getValidLanguages,
@@ -154,7 +154,7 @@ class App extends TsxComponent<AppProps> {
         locale || (this as any).$config?.FSXA_LOCALE || this.defaultLocale,
       initialPath: path ? path : this.currentPath,
       useExactDatasetRouting: isExactDatasetRoutingEnabled(this),
-      remoteDatasetProjectId: getRemoteDatasetProjectId(this),
+      remoteDatasetProxyApiPath: getRemoteDatasetProxyApiPath(this),
       remoteDatasetPageRefMapping: getRemoteDatasetPageRefMapping(this),
       validLanguages: getValidLanguages(this),
     };
@@ -173,7 +173,7 @@ class App extends TsxComponent<AppProps> {
         this.$store.getters[FSXAGetters.locale],
         this.$store.getters[FSXAGetters.getGlobalSettingsKey],
         isExactDatasetRoutingEnabled(this),
-        getRemoteDatasetProjectId(this),
+        getRemoteDatasetProxyApiPath(this),
         getRemoteDatasetPageRefMapping(this),
         getValidLanguages(this),
       );

--- a/src/components/base/BaseComponent.tsx
+++ b/src/components/base/BaseComponent.tsx
@@ -16,9 +16,9 @@ import {
   setNavigation,
   triggerRouteChange,
   isExactDatasetRoutingEnabled,
-  getRemoteDatasetProjectId,
   getRemoteDatasetPageRefMapping,
   getValidLanguages,
+  getRemoteDatasetProxyApiPath,
 } from "@/utils/getters";
 import { RequestRouteChangeParams } from "@/types/components";
 import {
@@ -86,7 +86,7 @@ class BaseComponent<
         this.locale,
         this.$store.getters[FSXAGetters.getGlobalSettingsKey],
         isExactDatasetRoutingEnabled(this),
-        getRemoteDatasetProjectId(this),
+        getRemoteDatasetProxyApiPath(this),
         getRemoteDatasetPageRefMapping(this),
         getValidLanguages(this),
       ),

--- a/src/store/actions/initializeApp.ts
+++ b/src/store/actions/initializeApp.ts
@@ -74,7 +74,7 @@ async function fetchNavigationOrNull(
 const baseUrl = (remoteProxyApiPath: string): string => {
   const host = (process as any).client
     ? window.location.origin
-    : `${process.env.NUXT_HOST}:${process.env.NUXT_PORT}` ||
+    : `http://${process.env.NUXT_HOST}:${process.env.NUXT_PORT}` ||
       "http://localhost:3000";
 
   return `${host}${remoteProxyApiPath}`;

--- a/src/store/actions/initializeApp.ts
+++ b/src/store/actions/initializeApp.ts
@@ -74,8 +74,8 @@ async function fetchNavigationOrNull(
 const baseUrl = (remoteProxyApiPath: string): string => {
   const host = (process as any).client
     ? window.location.origin
-    : `http://${process.env.NUXT_HOST}:${process.env.NUXT_PORT}` ||
-      "http://localhost:3000";
+    : `http://${process.env.NUXT_HOST || "localhost"}:${process.env.NUXT_PORT ||
+        "3000"}`;
 
   return `${host}${remoteProxyApiPath}`;
 };

--- a/src/store/actions/initializeApp.ts
+++ b/src/store/actions/initializeApp.ts
@@ -5,6 +5,7 @@ import {
   FetchNavigationParams,
   FSXAApi,
   FSXAApiErrors,
+  FSXAProxyApi,
   LogicalQueryOperatorEnum,
   NavigationData,
   QueryBuilderQuery,
@@ -70,10 +71,19 @@ async function fetchNavigationOrNull(
   }
 }
 
+const baseUrl = (remoteProxyApiPath: string): string => {
+  const host = (process as any).client
+    ? window.location.origin
+    : `${process.env.NUXT_HOST}:${process.env.NUXT_PORT}` ||
+      "http://localhost:3000";
+
+  return `${host}${remoteProxyApiPath}`;
+};
+
 export async function fetchDatasetByRoute(
   fsxaApi: FSXAApi,
   route: string,
-  remoteProjectId: string | undefined,
+  remoteProxyApiPath: string | undefined,
   pageRefMapping: Record<string, string> | undefined,
   validLanguages: string[] | undefined,
 ): Promise<Dataset | undefined> {
@@ -82,10 +92,11 @@ export async function fetchDatasetByRoute(
   });
   const localDataset = items[0];
 
-  if (!localDataset && remoteProjectId) {
-    const { items: remoteItems } = await fsxaApi.fetchByFilter({
+  if (!localDataset && remoteProxyApiPath) {
+    const { items: remoteItems } = await new FSXAProxyApi(
+      baseUrl(remoteProxyApiPath),
+    ).fetchByFilter({
       filters: createDatasetRouteFilters(route, validLanguages),
-      remoteProject: remoteProjectId,
     });
 
     const remoteDataset = remoteItems[0] as Dataset;
@@ -101,7 +112,7 @@ export interface InitializeAppPayload {
   locale: string;
   initialPath?: string;
   useExactDatasetRouting?: boolean;
-  remoteDatasetProjectId?: string;
+  remoteDatasetProxyApiPath?: string;
   remoteDatasetPageRefMapping?: Record<string, string>;
   validLanguages?: string[];
 }
@@ -121,7 +132,7 @@ export const createAppInitialization = (fsxaApi: FSXAApi) => async (
       const dataset = await fetchDatasetByRoute(
         fsxaApi,
         route,
-        payload.remoteDatasetProjectId,
+        payload.remoteDatasetProxyApiPath,
         payload.remoteDatasetPageRefMapping,
         payload.validLanguages,
       );

--- a/src/utils/getters.ts
+++ b/src/utils/getters.ts
@@ -83,7 +83,7 @@ export async function triggerRouteChange(
   currentLocale: string,
   globalSettingsKey?: string,
   useExactDatasetRouting?: boolean,
-  remoteDatasetProjectId?: string,
+  remoteProxyApiPath?: string,
   remoteDatasetPageRefMapping?: Record<string, string>,
   validLanguages?: string[],
 ): Promise<string | null> {
@@ -97,7 +97,7 @@ export async function triggerRouteChange(
         const dataset = await fetchDatasetByRoute(
           $fsxaApi,
           params.route,
-          remoteDatasetProjectId,
+          remoteProxyApiPath,
           remoteDatasetPageRefMapping,
           validLanguages,
         );
@@ -217,13 +217,13 @@ export function getValidLanguages(vue: Vue | undefined): string[] | undefined {
   return validLanguages;
 }
 
-export function getRemoteDatasetProjectId(
+export function getRemoteDatasetProxyApiPath(
   vue: Vue | undefined,
 ): string | undefined {
   // Assuming that pattern lib is used in Nuxt environment where $config is available.
-  const remoteProjectId =
-    (vue as any)?.$config?.FSXA_REMOTE_DATASET_PROJECT_ID || undefined;
-  return remoteProjectId;
+  const remoteDatasetProxyApiPath =
+    (vue as any)?.$config?.FSXA_REMOTE_DATASET_PROXY_API_PATH || undefined;
+  return remoteDatasetProxyApiPath;
 }
 
 export function getStoreTTL(vue: Vue): number {


### PR DESCRIPTION
…proxy api for remote datasets

Instead of resolving remote datasets the same way remote media is handled, use a separate proxy api. This ensures correct handling of languages and locales